### PR TITLE
feat: Add `--version` option

### DIFF
--- a/docs/djlint/usage.rst
+++ b/docs/djlint/usage.rst
@@ -62,3 +62,4 @@ CLI Args
       --check               Check formatting on the file(s).
       --quiet               Do not print diff when reformatting.
       -h, --help            Show this message and exit.
+      --version             Get djLint version

--- a/src/djlint/__init__.py
+++ b/src/djlint/__init__.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import List
 
 import click
+import pkg_resources
 from click import echo
 from colorama import Fore, Style, deinit, init
 from tqdm import tqdm
@@ -151,6 +152,7 @@ def build_quantity_tense(size: int) -> str:
     nargs=1,
     metavar="SRC ...",
 )
+@click.version_option(pkg_resources.get_distribution("djlint").version)
 @click.option(
     "-e",
     "--extension",

--- a/src/djlint/__init__.py
+++ b/src/djlint/__init__.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import List
 
 import click
-import pkg_resources
 from click import echo
 from colorama import Fore, Style, deinit, init
 from tqdm import tqdm
@@ -152,7 +151,7 @@ def build_quantity_tense(size: int) -> str:
     nargs=1,
     metavar="SRC ...",
 )
-@click.version_option(pkg_resources.get_distribution("djlint").version)
+@click.version_option(package_name="djlint")
 @click.option(
     "-e",
     "--extension",

--- a/tests/test_djlint.py
+++ b/tests/test_djlint.py
@@ -7,7 +7,7 @@ run::
 
 for a single test::
 
-    pytest tests/test_djlint.py::test_W010 --cov=src/djlint \
+    pytest tests/test_djlint.py::test_version --cov=src/djlint \
      --cov-branch --cov-report xml:coverage.xml --cov-report term-missing
 
 or::
@@ -19,6 +19,7 @@ or::
 from pathlib import Path
 from typing import TextIO
 
+import pkg_resources
 from click.testing import CliRunner
 
 from src.djlint import main as djlint
@@ -136,3 +137,8 @@ def test_check_reformatter_no_error(runner: CliRunner, tmp_file: TextIO) -> None
     result = runner.invoke(djlint, [tmp_file.name, "--check"])
     assert result.exit_code == 0
     assert "0 files would be updated." in result.output
+
+
+def test_version(runner: CliRunner) -> None:
+    result = runner.invoke(djlint, ["--version"])
+    assert pkg_resources.get_distribution("djlint").version in result.output


### PR DESCRIPTION
## Description

I thought it would be useful to have a `--version` option

## Capture

<img width="625" alt="feat-djlint-version" src="https://user-images.githubusercontent.com/188642/133703286-67f66b25-ef46-4d87-9ccd-4e127f2b5fa8.png">


