### PR TITLE
fix: broken link "djlint documentation" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Ps, ``--check`` it out on other templates as well!
 
 ## Documentation
 
-Read the [documentation](https://djlint.readthedocs.io)
+Read the [documentation](https://djlint.com)
 
 ## Installation and Usage
 


### PR DESCRIPTION
from `https://djlint.readthedocs.io` to `https://djlint.com/` 😇