### PR TITLE
Do not indent the <source> element, it does not permit content

### DIFF
--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -443,6 +443,7 @@ class Config:
               link
             | img
             | meta
+            | source
         """
 
         self.single_line_template_tags: str = r"""

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -227,7 +227,6 @@ class Config:
                     | path
                     | script
                     | style
-                    | source
                     | details
                     | summary
                 )
@@ -287,7 +286,6 @@ class Config:
                     | path
                     | script
                     | style
-                    | source
                     | details
                     | summary
                 )

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -199,3 +199,21 @@ def test_ignored_attributes(runner: CliRunner, tmp_file: TextIO) -> None:
      json-data='{"menu":{"header":"SVG Viewer","items":[{"id":"Open"}]}}'></div>
 """
     )
+
+
+def test_picture_source_img_tags(runner: CliRunner, tmp_file: TextIO) -> None:
+    write_to_file(
+        tmp_file.name,
+        b"""\
+<picture><source media="(max-width:640px)"
+srcset="image.jpg"><img src="image.jpg" alt="image"></picture>""",
+    )
+    runner.invoke(djlint, [tmp_file.name, "--reformat"])
+    assert (
+        Path(tmp_file.name).read_text()
+        == """<picture>
+    <source media="(max-width:640px)" srcset="image.jpg">
+    <img src="image.jpg" alt="image">
+</picture>
+"""
+    )


### PR DESCRIPTION
# Pull Request Check List

Resolves: #issue-number-here

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

The source element does not permit content therefore subsequent tags shouldn't be indented, see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source