### PR TITLE
Switch from tomlkit to tomli

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -251,14 +251,6 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
-name = "tomlkit"
-version = "0.10.1"
-description = "Style preserving TOML library"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "tqdm"
 version = "4.62.3"
 description = "Fast, Extensible Progress Meter"
@@ -308,7 +300,7 @@ test = ["coverage", "pytest", "pytest-cov"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7,<4.0"
-content-hash = "71537dcd92ed560e567b8f4a9e2362d347cc1100d65a3925d1eead25508cd2bf"
+content-hash = "b9e4cbf6e84631a25896da5849568d316919a5e1b5880d210fde7818c864ddb4"
 
 [metadata.files]
 atomicwrites = [
@@ -557,10 +549,6 @@ regex = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-tomlkit = [
-    {file = "tomlkit-0.10.1-py3-none-any.whl", hash = "sha256:3eba517439dcb2f84cf39f4f85fd2c3398309823a3c75ac3e73003638daf7915"},
-    {file = "tomlkit-0.10.1.tar.gz", hash = "sha256:3c517894eadef53e9072d343d37e4427b8f0b6200a70b7c9a19b2ebd1f53b951"},
 ]
 tqdm = [
     {file = "tqdm-4.62.3-py2.py3-none-any.whl", hash = "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ PyYAML = "^6.0"
 colorama = "^0.4.4"
 regex = "^2022.1.18"
 tqdm = "^4.62.2"
-tomlkit = "^0.10.0"
+tomli = { version = "^2.0.1", python = "<3.11" }
 coverage = { version = "^6.3.1", optional = true }
 pytest = { version = "^7.0.1", optional = true }
 pytest-cov = { version = "^3.0.0", optional = true }
@@ -60,7 +60,6 @@ use_parentheses = true
 ensure_newline_before_comments = true
 line_length = 99
 quiet = true
-
 
 [tool.pylint.messages_control]
 disable = "E1120, R0914, E0401, R0912, R0916, R0913, W0104, R0801, W1404, R0902, R0903, R1732, R0915, C0301, R1702"

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,7 @@ pathspec==0.9.0; (python_version >= "2.7" and python_full_version < "3.0.0") or 
 platformdirs==2.5.0; python_version >= "3.7" and python_full_version >= "3.6.2"
 pyyaml==6.0; python_version >= "3.6"
 regex==2022.1.18
-tomli==2.0.1; python_version >= "3.7" and python_full_version >= "3.6.2"
-tomlkit==0.10.1; python_version >= "3.6" and python_version < "4.0"
+tomli==2.0.1; python_version >= "3.7" and python_full_version >= "3.6.2" or python_version < "3.11"
 tqdm==4.62.3; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 typed-ast==1.4.3; python_version < "3.8" and implementation_name == "cpython" and python_full_version >= "3.6.2"
 typing-extensions==4.1.0; python_version < "3.8" and python_version >= "3.7" and python_full_version >= "3.6.2"

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -19,7 +19,7 @@ from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib
+    import tomli as tomllib  # type: ignore
 
 logger = logging.getLogger(__name__)
 

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -10,12 +10,16 @@ import logging
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-import tomlkit
 import yaml
 from click import echo
 from colorama import Fore
 from pathspec import PathSpec
 from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +101,7 @@ def load_project_settings(src: Path) -> Dict:
     pyproject_file = find_pyproject(src)
 
     if pyproject_file:
-        content = tomlkit.parse(pyproject_file.read_text(encoding="utf8"))
+        content = tomllib.load(pyproject_file.open("rb"))
         try:
             return content["tool"]["djlint"]  # type: ignore
         except KeyError:


### PR DESCRIPTION
Tomli is the upcoming python 3.11 standard library toml parser,
 and will be available as tomllib when 3.11 releases.

This switches from using tomlkit to tomli, which brings it inline
 with black, poetry, and many other toml parsing python packages
