### PR TITLE
Update H026 regex to ignore hyphens before and after class/id

### DIFF
--- a/src/djlint/rules.yaml
+++ b/src/djlint/rules.yaml
@@ -191,7 +191,7 @@
     flags: re.I
     patterns:
     - <\w+\b[^(?:{(?:%|{|#))>]*?\b(class|id)\b=(\"\"|'')
-    - <\w+\b[^(?:{(?:%|{|#))>]*?\b(class|id)\b[^=\"]
+    - <\w+\b[^(?:{(?:%|{|#))>-]*?\b(class|id)\b[^=\"-]
 - rule:
     name: T027
     message: Unclosed string found in template syntax.

--- a/tests/test_linter/test_linter.py
+++ b/tests/test_linter/test_linter.py
@@ -549,6 +549,10 @@ def test_H026(runner: CliRunner, tmp_file: TextIO) -> None:
     assert result.exit_code == 0
     assert "H026" not in result.output
 
+    write_to_file(tmp_file.name, b"<div x-id-y><div id-y><div x-id>")
+    result = runner.invoke(djlint, [tmp_file.name])
+    assert "H026" not in result.output
+
 
 def test_T027(runner: CliRunner, tmp_file: TextIO) -> None:
     write_to_file(tmp_file.name, b"{% blah 'asdf %}")


### PR DESCRIPTION
Avoids matching

```
<div x-id-y
<div id-y
<div x-id
```

etc.

Resolves: #281 

