### PR TITLE
adds missing shebang in node binary

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const process = require('process');
 const { PythonShell } = require('python-shell');
 

--- a/renovate.json
+++ b/renovate.json
@@ -9,16 +9,13 @@
     ":npm",
     "npm:unpublishSafe"
   ],
-  "ignoreDeps": ["@fortawesome/fontawesome-free"],
-  "assignees": [
-    "christopherpickering"
-  ],
   "bumpVersion": "patch",
   "commitMessagePrefix": "chore(deps)",
   "labels": [
     "maintenance", 
     "renovate"
   ],
+  "baseBranches": ["dev"],
   "packageRules": [
     {
       "matchUpdateTypes": ["pin","digest"],


### PR DESCRIPTION
# What this PR for
I noticed syntax error when trying to run `djlint` binary installed with `npm`.
Just looked at the code and found that it was a node.js file used as a binary but without a shebang, so my system was not able to run it.

I tested locally, it fixes my issue.

Let me know if it's good for you!

# Pull Request Check List

Resolves: no issue

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.