### PR TITLE
Add a link to the djlint-vscode page on Open VSX

### DIFF
--- a/docs/src/docs/integrations.md
+++ b/docs/src/docs/integrations.md
@@ -71,8 +71,9 @@ Ensure djLint is installed in your global python, or on your `PATH`.
 
 ::: content
 
-- [Marketplace page](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
 - [GitHub repository](https://github.com/monosans/djlint-vscode)
+- [VS Marketplace page](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
+- [Open VSX page](https://open-vsx.org/extension/monosans/djlint)
   :::
 
 ## neovim

--- a/docs/src/fr/docs/integrations.md
+++ b/docs/src/fr/docs/integrations.md
@@ -71,8 +71,9 @@ Assurez-vous que djLint est installé dans votre python global, ou sur votre `PA
 
 ::: content
 
-- [Page du marché](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
 - [GitHub dépôt](https://github.com/monosans/djlint-vscode)
+- [Page sur VS Marketplace](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
+- [Page sur Open VSX](https://open-vsx.org/extension/monosans/djlint)
   :::
 
 ## neovim

--- a/docs/src/ru/docs/integrations.md
+++ b/docs/src/ru/docs/integrations.md
@@ -71,8 +71,9 @@ djLint можно использовать в качестве плагина Su
 
 ::: content
 
-- [Страница рынка](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
 - [GitHub репозиторий](https://github.com/monosans/djlint-vscode)
+- [Страница на VS Marketplace](https://marketplace.visualstudio.com/items?itemName=monosans.djlint)
+- [Страница на Open VSX](https://open-vsx.org/extension/monosans/djlint)
   :::
 
 ## neovim


### PR DESCRIPTION
I also edited the translations a bit, because Visual Studio Marketplace is a proper name, so I don't think you need to translate it.