### PR TITLE
Emit errors on stderr

### DIFF
--- a/src/djlint/output.py
+++ b/src/djlint/output.py
@@ -77,7 +77,7 @@ def print_output(
         lint_success_color = (
             Fore.RED + Style.BRIGHT if (lint_error_count) > 0 else Fore.BLUE
         )
-        echo(f"{lint_success_color}{lint_success_message}{Style.RESET_ALL}")
+        echo(f"{lint_success_color}{lint_success_message}{Style.RESET_ALL}", err=True)
 
     if print_blanks:
         echo()
@@ -132,7 +132,7 @@ def build_output(error: dict, config: Config) -> int:
             config.linter_output_format.format(
                 filename=filename, line=line, code=code, message=message, match=match
             ),
-            err=False,
+            err=True,
         )
 
     return len(errors)


### PR DESCRIPTION
I'm having some issue trying to integrate djLint with my IDE because the IDE expects that, in case of linting errors, these errors are output on stderr (instead of stdout).

These changes fix my problems and pass the djLint tests. \
However I see that on l.135 the argument `err` was explicitly set to `err=False`, so I think I'm missing something...

I don't feel that it's important to change any part of the documentation about this slightly changed behavior.