### PR TITLE
Allow data: for links.

### DIFF
--- a/src/djlint/rules.yaml
+++ b/src/djlint/rules.yaml
@@ -135,14 +135,14 @@
     message: (Django) Internal links should use the {% url ... %} pattern.
     flags: re.DOTALL|re.I
     patterns:
-    - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/]+
+    - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:)[\w|/]+
     - <form\s+?[^>]*?(?:action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/]+
 - rule:
     name: J018
     message: (Jinja) Internal links should use the {{ url_for() ... }} pattern.
     flags: re.DOTALL|re.I
     patterns:
-    - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/]+
+    - <(?:a|div|span|input)\b[^>]*?\s(?:href|data-url|data-src|action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:|data:)[\w|/]+
     - <form\s+?[^>]*?(?:action)=[\"|'](?!(?:https?://)|javascript:|on\w+:|mailto:|tel:)[\w|/]+
 - rule:
     name: H019

--- a/tests/test_linter/test_linter.py
+++ b/tests/test_linter/test_linter.py
@@ -417,13 +417,29 @@ def test_DJ018(runner: CliRunner, tmp_file: TextIO) -> None:
     result = runner.invoke(djlint, [tmp_file.name, "--profile", "jinja"])
     assert "J018 1:" in result.output
 
-    # test mailto:
+    # test mailto:, tel:
     write_to_file(
         tmp_file.name,
         b'<a href="mailto:joe"></a><a href="tel:joe"></a>',
     )
-    result = runner.invoke(djlint, [tmp_file.name])
+    result = runner.invoke(djlint, [tmp_file.name, "--profile", "django"])
     assert result.exit_code == 0
+    assert "D018" not in result.output
+    result = runner.invoke(djlint, [tmp_file.name, "--profile", "jinja"])
+    assert result.exit_code == 0
+    assert "J018" not in result.output
+
+    # test data:
+    write_to_file(
+        tmp_file.name,
+        b'<a href="data:,Hello%2C%20World%21"></a>',
+    )
+    result = runner.invoke(djlint, [tmp_file.name, "--profile", "django"])
+    assert result.exit_code == 0
+    assert "D018" not in result.output
+    result = runner.invoke(djlint, [tmp_file.name, "--profile", "jinja"])
+    assert result.exit_code == 0
+    assert "J018" not in result.output
 
     # test attribute names
     write_to_file(


### PR DESCRIPTION
# Pull Request Check List


- [X] Added **tests** for changed code.
- [X] Updated **documentation** for changed code.

See https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs

This PR allow `"data:"` links without `"{% url "` pattern. 
It also fixes tests for "mailto:" and "tel:" that didn't use a profile and passed even without the correct rule.

Example:
```html
<a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==">Text link</a>
```

