### PR TITLE
[front] Integration.md - Update github repo url

### DIFF
--- a/docs/src/fr/docs/integrations.md
+++ b/docs/src/fr/docs/integrations.md
@@ -34,7 +34,7 @@ Notez que ces hooks prédéfinis sont parfois trop conservateurs dans les entré
 
 ```yaml
 repos:
-  - repo: https://github.com/Riverside-Healthcare/djLint
+  - repo: https://github.com/Riverside-Healthcare/djlint
     rev: 0.5.10 # grab latest tag from GitHub
     hooks:
       - id: djlint-django
@@ -44,7 +44,7 @@ repos:
 
 ```yaml
 repos:
-  - repo: https://github.com/Riverside-Healthcare/djLint
+  - repo: https://github.com/Riverside-Healthcare/djlint
     rev: 0.5.10 # grab latest tag from GitHub
     hooks:
       - id: djlint-handlebars


### PR DESCRIPTION
The github url is wrong : 
- https://github.com/Riverside-Healthcare/djLint to https://github.com/Riverside-Healthcare/djlint



# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
