### PR TITLE
docs: inject the latest djlint version number

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -85,6 +85,7 @@ const widont = (string) => {
 };
 
 module.exports = function (eleventyConfig) {
+  eleventyConfig.addGlobalData("djlint_version", require('../package.json').version);
   eleventyConfig.setUseGitIgnore(false);
   eleventyConfig.addFilter('widont', widont);
   eleventyConfig.addWatchTarget('./src/static/');

--- a/docs/src/docs/integrations.md
+++ b/docs/src/docs/integrations.md
@@ -35,7 +35,7 @@ Note that these predefined hooks are sometimes too conservative in the inputs th
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-django
 ```
@@ -45,7 +45,7 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-handlebars
         files: "\\.html"

--- a/docs/src/fr/docs/integrations.md
+++ b/docs/src/fr/docs/integrations.md
@@ -35,7 +35,7 @@ Notez que ces hooks prédéfinis sont parfois trop conservateurs dans les entré
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-django
 ```
@@ -45,7 +45,7 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-handlebars
         files: "\\.html"

--- a/docs/src/ru/docs/integrations.md
+++ b/docs/src/ru/docs/integrations.md
@@ -35,7 +35,7 @@ djLint можно использовать как [pre-commit](https://pre-commi
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-django
 ```
@@ -45,7 +45,7 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: 0.5.10 # grab latest tag from GitHub
+    rev: {{ djlint_version }}
     hooks:
       - id: djlint-handlebars
         files: "\\.html"


### PR DESCRIPTION
Hello, I noticed the version number of djlint is a bit old on the pre-commit configuration section of the documentation, and readers have to check the latest version number manually. This PR allows using the latest version number automatically using `package.json`'s `version` property so that reader can just copy and paste the configuration without a manual modification.

Here are screenshots of this change:

**before**
<img width="811" alt="Screenshot 2023-01-09 at 13 43 41" src="https://user-images.githubusercontent.com/1425259/211243255-4f627c5e-50f8-44cf-beba-3914f85f7f6f.png">

**after**
<img width="616" alt="Screenshot 2023-01-09 at 13 49 02" src="https://user-images.githubusercontent.com/1425259/211243249-b30fc0a8-f96b-403a-abeb-4ac582c6a382.png">

# Pull Request Check List

Resolves: #issue-number-here (sorry, I skipped)

- [ ] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
