### PR TITLE
Document the additional extensions considered by pre-commit for jinja

### DIFF
--- a/docs/src/docs/integrations.md
+++ b/docs/src/docs/integrations.md
@@ -19,7 +19,7 @@ The repo provides multiple pre-configured hooks for specific djLint profiles (it
 - `djlint-django` for Django templates:
   This will look for files matching `templates/**.html` and set `--profile=django`.
 - `djlint-jinja`
-  This will look for files matching `*.j2` and set `--profile=jinja`.
+  This will look for files matching `*.j2`,`*.jinja` or `*.jinja2`  and set `--profile=jinja`.
 - `djlint-nunjucks`
   This will look for files matching `*.njk` and set `--profile=nunjucks`.
 - `djlint-handlebars`

--- a/docs/src/docs/integrations.md
+++ b/docs/src/docs/integrations.md
@@ -19,7 +19,7 @@ The repo provides multiple pre-configured hooks for specific djLint profiles (it
 - `djlint-django` for Django templates:
   This will look for files matching `templates/**.html` and set `--profile=django`.
 - `djlint-jinja`
-  This will look for files matching `*.j2`,`*.jinja` or `*.jinja2`  and set `--profile=jinja`.
+  This will look for files matching `*.j2`,`*.jinja` or `*.jinja2` and set `--profile=jinja`.
 - `djlint-nunjucks`
   This will look for files matching `*.njk` and set `--profile=nunjucks`.
 - `djlint-handlebars`

--- a/docs/src/fr/docs/integrations.md
+++ b/docs/src/fr/docs/integrations.md
@@ -19,7 +19,7 @@ Le repo fournit de multiples hooks pré-configurés pour des profils djLint spé
 - `djlint-django` pour les modèles Django :
   Il recherchera les fichiers correspondant à `templates/**.html` et définira `--profile=django`.
 - `djlint-jinja`
-  Ceci recherchera les fichiers correspondant à `*.j2` et définira `--profile=jinja`.
+  Ceci recherchera les fichiers correspondant à `*.j2`, `*.jinja` ou `*.jinja2` et définira `--profile=jinja`.
 - `djlint-nunjucks`
   Cette commande recherchera les fichiers correspondant à `*.njk` et définira `--profile=nunjucks`.
 - `djlint-handlebars`

--- a/docs/src/ru/docs/integrations.md
+++ b/docs/src/ru/docs/integrations.md
@@ -19,7 +19,7 @@ djLint можно использовать как [pre-commit](https://pre-commi
 - `djlint-django` для шаблонов Django:
   Это будет искать файлы, соответствующие `templates/**.html` и устанавливать `--profile=django`.
 - `djlint-jinja`.
-  Это будет искать файлы, соответствующие `*.j2` и устанавливать `--профиль=jinja`.
+  Это будет искать файлы, соответствующие `*.j2`, `*.jinja` или `*.jinja2` и устанавливать `--профиль=jinja`.
 - `djlint-nunjucks`.
   Будет искать файлы, соответствующие `*.njk` и устанавливать `--profile=nunjucks`.
 - `djlint-handlebars`


### PR DESCRIPTION
# Pull Request Check List

Resolves: #undefined

- [ ] Added **tests** for changed code.
- [ x] Updated **documentation** for changed code.


Document the additional extensions that pre-commit will use when specifying `types_or: [jinja]` in the hook config. I actually got confused by the current doc, thinking it would only consider .j2 

pre-commit uses 'identity' to identify file extensions, for jinja the list of extensions can be seen  [here](https://github.com/pre-commit/identify/blob/main/identify/extensions.py#L107)

Thanks for the library btw, pretty cool!