### PR TITLE
Defining custom blocks isn't strict enough

### DIFF
--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -187,7 +187,9 @@ def build_custom_blocks(custom_blocks: Union[str, None]) -> Optional[str]:
         # need to also do "end<tag>"
         open_tags = [x.strip() for x in custom_blocks.split(",")]
         close_tags = ["end" + x.strip() for x in custom_blocks.split(",")]
-        return "|" + "|".join(sorted(set(open_tags + close_tags)))
+        # Group all tags together with a negative lookahead.
+        tags = set([tag + r"(?!.*\d)\b" for tag in open_tags + close_tags])
+        return "|" + "|".join(sorted(tags))
     return None
 
 

--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -188,7 +188,7 @@ def build_custom_blocks(custom_blocks: Union[str, None]) -> Optional[str]:
         open_tags = [x.strip() for x in custom_blocks.split(",")]
         close_tags = ["end" + x.strip() for x in custom_blocks.split(",")]
         # Group all tags together with a negative lookahead.
-        tags = set([tag + r"(?!.*\d)\b" for tag in open_tags + close_tags])
+        tags = set([tag + r"\b" for tag in open_tags + close_tags])
         return "|" + "|".join(sorted(tags))
     return None
 

--- a/tests/test_config/test_custom_blocks.py
+++ b/tests/test_config/test_custom_blocks.py
@@ -29,6 +29,22 @@ test_data = [
         ({"custom_blocks": "toc,example,verylongexampletagthatiskindaneattolookat"}),
         id="one",
     ),
+    pytest.param(
+        (
+            "{% custom_block %}\n"
+            "    {% custom_block_but_different %}\n"
+            "    <p>some other content</p>\n"
+            "{% endcustom_block %}\n"
+        ),
+        (
+            "{% custom_block %}\n"
+            "    {% custom_block_but_different %}\n"
+            "    <p>some other content</p>\n"
+            "{% endcustom_block %}\n"
+        ),
+        ({"custom_blocks": "custom_block"}),
+        id="custom_block_with_similar_tag",
+    ),
 ]
 
 

--- a/tests/test_config/test_djlintrc/test_config.py
+++ b/tests/test_config/test_djlintrc/test_config.py
@@ -14,7 +14,10 @@ def test_default() -> None:
     assert config.exclude == ".venv,venv,.tox,.eggs,... | .custom"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert config.custom_blocks == "|endexample|endtoc|example|toc"
+    assert (
+        config.custom_blocks
+        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
+    )
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]

--- a/tests/test_config/test_djlintrc/test_config.py
+++ b/tests/test_config/test_djlintrc/test_config.py
@@ -14,10 +14,7 @@ def test_default() -> None:
     assert config.exclude == ".venv,venv,.tox,.eggs,... | .custom"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert (
-        config.custom_blocks
-        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
-    )
+    assert config.custom_blocks == r"|endexample\b|endtoc\b|example\b|toc\b"
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]

--- a/tests/test_config/test_djlintrc_custom/test_config.py
+++ b/tests/test_config/test_djlintrc_custom/test_config.py
@@ -18,10 +18,7 @@ def test_custom() -> None:
     assert config.exclude == ".venv,venv,.tox,.egg,... | .customs"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert (
-        config.custom_blocks
-        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
-    )
+    assert config.custom_blocks == r"|endexample\b|endtoc\b|example\b|toc\b"
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]

--- a/tests/test_config/test_djlintrc_custom/test_config.py
+++ b/tests/test_config/test_djlintrc_custom/test_config.py
@@ -18,7 +18,10 @@ def test_custom() -> None:
     assert config.exclude == ".venv,venv,.tox,.egg,... | .customs"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert config.custom_blocks == "|endexample|endtoc|example|toc"
+    assert (
+        config.custom_blocks
+        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
+    )
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]

--- a/tests/test_config/test_pyproject/test_config.py
+++ b/tests/test_config/test_pyproject/test_config.py
@@ -14,7 +14,10 @@ def test_profile() -> None:
     assert config.exclude == "foo/excluded.html | excluded.html"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert config.custom_blocks == "|endexample|endtoc|example|toc"
+    assert (
+        config.custom_blocks
+        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
+    )
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]

--- a/tests/test_config/test_pyproject/test_config.py
+++ b/tests/test_config/test_pyproject/test_config.py
@@ -14,10 +14,7 @@ def test_profile() -> None:
     assert config.exclude == "foo/excluded.html | excluded.html"
     assert config.blank_line_after_tag == "load,extends,include"
     assert config.blank_line_before_tag == "load,extends,include"
-    assert (
-        config.custom_blocks
-        == r"|endexample(?!.*\d)\b|endtoc(?!.*\d)\b|example(?!.*\d)\b|toc(?!.*\d)\b"
-    )
+    assert config.custom_blocks == r"|endexample\b|endtoc\b|example\b|toc\b"
     assert config.custom_html == r"|mjml|simple-greeting|mj-\w+"
     assert config.extension == "html.dj"
     assert config.files == ["index.html"]


### PR DESCRIPTION
# The issue?

If you define a custom block of `new_thing` but have a tag in your code `{% new_thing_2 %}` the current code will apply the custom blocks logic to `new_thing_2` even though it's not specified in the `custom_blocks` setting.

# The fix?

Adding a negative lookahead to the tags in the regex so that it only matches EXACT matches.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code. (not needed?)
