### PR TITLE
fix(formatter): reverted chained function formatting

### DIFF
--- a/tests/test_nunjucks/test_filters.py
+++ b/tests/test_nunjucks/test_filters.py
@@ -1,0 +1,42 @@
+"""Test nunjucks filters.
+
+poetry run pytest tests/test_nunjucks/test_filters.py
+"""
+import pytest
+
+from src.djlint.reformat import formatter
+from tests.conftest import config_builder, printer
+
+test_data = [
+    pytest.param(
+        (
+            "{% set absoluteUrl %}{{ page.url | htmlBaseUrl(metadata.url) }}{% endset %}\n"
+        ),
+        (
+            "{% set absoluteUrl %}\n"
+            "    {{ page.url | htmlBaseUrl(metadata.url) }}\n"
+            "{% endset %}\n"
+        ),
+        ({}),
+        id="one",
+    ),
+    pytest.param(
+        (
+            "{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}"
+        ),
+        (
+            "{{ post.templateContent | transformWithHtmlBase(absolutePostUrl, post.url) | dump | safe }}\n"
+        ),
+        ({}),
+        id="two",
+    ),
+]
+
+
+@pytest.mark.parametrize(("source", "expected", "args"), test_data)
+def test_base(source, expected, args, nunjucks_config):
+    args["profile"] = "nunjucks"
+    output = formatter(config_builder(args), source)
+
+    printer(expected, source, output)
+    assert expected == output

--- a/tests/test_nunjucks/test_functions.py
+++ b/tests/test_nunjucks/test_functions.py
@@ -37,6 +37,7 @@ test_data = [
         (
             '{{ item.split("/")[1] }}\n'
             '{{ item.split("/").123 }}\n'
+            # https://github.com/Riverside-Healthcare/djLint/issues/704
             '{{ item.split("/").bar }}\n'
         ),
         ({}),
@@ -44,12 +45,14 @@ test_data = [
     ),
     pytest.param(
         ("{{ url('foo').foo }}"),
+        # https://github.com/Riverside-Healthcare/djLint/issues/704
         ('{{ url("foo").foo }}\n'),
         ({}),
         id="function_call_attribute_access",
     ),
     pytest.param(
         ("{{ url('foo').foo().bar[1] }}"),
+        # https://github.com/Riverside-Healthcare/djLint/issues/704
         ('{{ url("foo").foo().bar[1] }}\n'),
         ({}),
         id="function_call_attribute_access_multiple",


### PR DESCRIPTION
This update reverts the formatting on of chained functions as it broke filter strings, but at the same time leaves in a fix for extra spaces that the original issue found.

re #720, #704



# Pull Request Check List

Resolves: #issue-number-here

- [ ] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
