### PR TITLE
Fix `.djlintrc` config loading

### DIFF
--- a/src/djlint/settings.py
+++ b/src/djlint/settings.py
@@ -143,7 +143,6 @@ def load_project_settings(src: Path, config: Optional[str]) -> Dict:
     if djlintrc_file:
         try:
             djlint_content.update(load_djlintrc_config(djlintrc_file))
-            return content
         # pylint: disable=broad-except
         except BaseException as error:
             logger.error("%sFailed to load .djlintrc file. %s", Fore.RED, error)


### PR DESCRIPTION
# Pull Request Check List

Resolves: #767 

It removes an unnecessary `return` statement. It's strange how such an error could be made in #759, because even **PyCharm** warns about this `return` :sweat_smile:

![image](https://github.com/Riverside-Healthcare/djLint/assets/103030080/b2ec88f8-c6a1-422a-9e27-8ccfec840eb5)

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
