### PR TITLE
Fix missed H025 for double closing HTML tags

### DIFF
--- a/src/djlint/rules/H025.py
+++ b/src/djlint/rules/H025.py
@@ -25,6 +25,8 @@ def run(
     """Check for orphans html tags."""
     errors: List[Dict[str, str]] = []
     open_tags: List[re.Match] = []
+    orphan_tags: List[re.Match] = []
+
     for match in re.finditer(
         re.compile(
             r"<(/?(\w+))\s*(" + config.attribute_pattern + r"|\s*)*\s*?>",
@@ -46,9 +48,9 @@ def run(
                         break
                 else:
                     # there was no open tag matching the close tag
-                    open_tags.insert(0, match)
+                    orphan_tags.append(match)
 
-    for match in open_tags:
+    for match in open_tags + orphan_tags:
         if (
             overlaps_ignored_block(config, html, match) is False
             and inside_ignored_rule(config, html, match, rule["name"]) is False

--- a/tests/test_linter/test_linter.py
+++ b/tests/test_linter/test_linter.py
@@ -390,6 +390,18 @@ def test_H025(runner: CliRunner, tmp_file: TextIO) -> None:
     )
     assert "H025" not in result.output
 
+    write_to_file(tmp_file.name, b"</p></p>")
+    result = runner.invoke(djlint, [tmp_file.name])
+    assert result.exit_code == 1
+    assert "H025 1:0" in result.output
+    assert "H025 1:4" in result.output
+
+    write_to_file(tmp_file.name, b"</p><p></p></p>")
+    result = runner.invoke(djlint, [tmp_file.name])
+    assert result.exit_code == 1
+    assert "H025 1:0" in result.output
+    assert "H025 1:11" in result.output
+
 
 def test_T027(runner: CliRunner, tmp_file: TextIO) -> None:
     write_to_file(tmp_file.name, b"<a href=\"{{- blah 'asdf' }}\">")


### PR DESCRIPTION
I couldn't see any reason to keep orphaned closing tags in `open_tags` so store them separately to avoid accidental matches against subsequent closing tags.

# Pull Request Check List

Resolves: #786

- [X] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.

<!-- If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing! -->
