### PR TITLE
fix(formatter): Avoid rewriting the file if it has not been changed

### DIFF
--- a/src/djlint/reformat.py
+++ b/src/djlint/reformat.py
@@ -52,7 +52,9 @@ def reformat_file(config: Config, this_file: Path) -> dict:
 
     beautified_code = formatter(config, rawcode)
 
-    if config.check is not True or config.stdin is True:
+    if (
+        config.check is not True and beautified_code != rawcode
+    ) or config.stdin is True:
         this_file.write_bytes(beautified_code.encode("utf8"))
 
     out = {

--- a/tests/test_djlint/test_djlint.py
+++ b/tests/test_djlint/test_djlint.py
@@ -23,6 +23,7 @@ except ImportError:
 
 
 # pylint: disable=C0116
+from os.path import getmtime
 from pathlib import Path
 from typing import TextIO
 
@@ -172,6 +173,16 @@ def test_reformatter_simple_error(runner: CliRunner, tmp_file: TextIO) -> None:
     result = runner.invoke(djlint, [tmp_file.name, "--reformat"])
     assert result.exit_code == 1
     assert "1 file was updated." in result.output
+
+
+def test_reformatter_no_error(runner: CliRunner, tmp_file: TextIO) -> None:
+    write_to_file(tmp_file.name, b"<div>\n    <p>nice stuff here</p>\n</div>\n")
+    old_mtime = getmtime(tmp_file.name)
+    result = runner.invoke(djlint, [tmp_file.name, "--reformat"])
+    assert result.exit_code == 0
+    assert "0 files were updated." in result.output
+    new_mtime = getmtime(tmp_file.name)
+    assert new_mtime == old_mtime
 
 
 def test_check_reformatter_simple_error_quiet(


### PR DESCRIPTION
We use djLint as part of [treefmt][1] to reformat HTML templates tree-wide, and treefmt [looks][2] at file modification time to determine if it was reformatted or not. And with `--fail-on-change` option passed, it exits with status 1 when it thinks files are modified.

This patch makes djLint not rewrite the file if there are no changes to write back, which makes `treefmt --fail-on-change` do the right thing.

[1]: https://github.com/numtide/treefmt
[2]: https://github.com/numtide/treefmt/blob/v0.6.1/src/engine.rs#L278

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.